### PR TITLE
Helper script to build with javac 10&ant

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+ $JAVA_HOME/bin/javac -d "build/classes" -sourcepath .  -cp com/logica/smpp/*/*.java -g -Xlint:deprecation -Xlint:unchecked
+ant jar

--- a/build.xml
+++ b/build.xml
@@ -11,7 +11,9 @@
     <javac classpathref="classpath"
 	   srcdir="."
 	   destdir="build/classes"
-	   includeantruntime="false"/>
+	   includeantruntime="true"
+	   debug="true"
+	   debuglevel="lines,vars,source"/>
   </target>
 
   <target name="jar" depends="compile">


### PR DESCRIPTION
Building with ant version : "Apache Ant(TM) version 1.9.9 compiled on June 29 2017"
And Javac version: "javac 10.0.1",
is not generating debug info even when specified debug="true" in the
build.xml and it also generates many warnings that has to do with java 10
which I will fix in the source code in the future
In the mean time,
To solve this I created build.sh that runs the javac command to build this project and ignore warnings
and then run "ant jar" which will only generate the jar file, as the class files were already built.